### PR TITLE
Test: Define Protected Settings

### DIFF
--- a/WindowsVirtualMachine/main.tf
+++ b/WindowsVirtualMachine/main.tf
@@ -162,6 +162,7 @@ resource "azurerm_virtual_machine_extension" "mde_windows" {
   type                       = "MDE.Windows"
   type_handler_version       = "1.0"
   auto_upgrade_minor_version = true
+  protected_settings         = jsonencode({})
 
   lifecycle {
     ignore_changes = [tags, settings]


### PR DESCRIPTION
Defining protected_settings within the resource, even as an emtpy array prevents the following bug from occuring. This is currently stopping us from deploying vm's in azdev.

---
VM has reported a failure when processing extension 'MDE.Windows' (publisher 'Microsoft.Azure.AzureDefenderForServers' and type 'MDE.Windows'). Error message: 'Failed to configure Microsoft Defender for Endpoint: You cannot call a method on a null-valued expression
